### PR TITLE
fix: Update KnowNothing reference to address number of messages provided

### DIFF
--- a/include/easykey.hpp
+++ b/include/easykey.hpp
@@ -15,7 +15,7 @@ public:
    * NOTE: The @param input must be a valid Know Nothing protocol message,
    * otherwise, we will have an undefined behavior
    */
-  static RequestMessage read(std::uint8_t *input);
+  static RequestMessage read(std::vector<std::uint8_t> input);
   const knownothing::Protocol kn_protocol;
   const std::string key;
   const std::vector<std::uint8_t> value;

--- a/include/know_nothing.hpp
+++ b/include/know_nothing.hpp
@@ -1,7 +1,9 @@
 #pragma once
 
 #include <array>
+#include <bits/stdint-uintn.h>
 #include <cstdint>
+#include <vector>
 
 namespace knownothing {
 
@@ -21,5 +23,7 @@ std::array<std::uint8_t, 4> serialize(std::uint32_t number);
 enum Protocol : std::uint8_t {
   V1 = 0x01,
 };
+
+bool check_integrity(std::vector<uint8_t> input);
 
 }; // namespace knownothing

--- a/main.cpp
+++ b/main.cpp
@@ -16,6 +16,7 @@ int main() {
   // Client sends this data
   uint8_t byte_array[] = {
       0x01, // knownothing protocol version
+      0x01, // The number of messages in the content
       0x04, // The first message size first byte
       0x00, // The first message size second byte
       0x00, // The first message size third byte
@@ -37,24 +38,11 @@ int main() {
       's'   // The second message seventh byte
   };
 
-  const auto message = RequestMessage::read(byte_array);
+  vector<uint8_t> vec(
+      byte_array, byte_array + (sizeof(byte_array) / sizeof(byte_array[0])));
+
+  const auto message = RequestMessage::read(vec);
   cout << message.key << endl;
 
-  vector<uint8_t> temp;
-  for (int index = 0; index < 66000; index++) {
-    temp.push_back(index);
-  }
-
-  const auto responseMessage =
-      ResponseMessage{Protocol::V1, ResponseMessage::StatusCode::OK, temp};
-
-  const auto responseBytes = responseMessage.write();
-  for (unsigned int index = 0; index < responseBytes.size(); index++) {
-    uint8_t v = responseBytes[index];
-
-    cout << "Index: [" << to_string(index) << "]"
-         << " - " << to_string(v) << endl;
-  }
-  cout << endl;
   return 0;
 }

--- a/source/know_nothing.cpp
+++ b/source/know_nothing.cpp
@@ -25,3 +25,38 @@ array<uint8_t, 4> knownothing::serialize(uint32_t number) {
 
   return array;
 }
+
+/**
+ * This needs to be done, because the kernel has a single buffer for the file
+ * descriptors, so it just stores data without limitations
+ */
+bool knownothing::check_integrity(vector<uint8_t> input) {
+  if (input.size() < 2) {
+    return false;
+  }
+
+  uint32_t current_position = 0;
+
+  // For now, just the first protocol is supported!
+  if (input[current_position++] != Protocol::V1) {
+    return false;
+  }
+  uint8_t messages_number = input[current_position++];
+  if (messages_number == 0) {
+    // At least, one message must be provided!
+    return false;
+  }
+
+  // Validates the messages(size and the rovided at messages number)
+  for (uint32_t index = 0; index < messages_number; index++) {
+    uint32_t message_size =
+        deserialize({input[current_position++], input[current_position++],
+                     input[current_position++], input[current_position++]});
+
+    // move to the next message size
+    current_position += message_size;
+  }
+  // validates if the messages numbers and the messages with their sizes matches
+  // with the input size
+  return current_position == input.size();
+}


### PR DESCRIPTION
This update in the specification is needed, because the kernel stores the content to be read in a single buffer, so we need to know exactly where one message ends and when another starts