### PR TITLE
feat: Allow user to set socket options #11

### DIFF
--- a/include/server.hpp
+++ b/include/server.hpp
@@ -41,6 +41,64 @@ class Socket
     // TOOD: THis must not be public!
     const std::int32_t file_descriptor;
 
+    /**
+     * The socket options.
+     * This class is used to retrieve information from the user, without the
+     * need of him to specify it
+     */
+    template <typename OPTION_TYPE>
+    struct Option
+    {
+      private:
+        Option(const std::int32_t value);
+
+      public:
+        /**
+        * The optname argument
+        )*/
+        const std::int32_t value;
+
+        /**
+         * The optlen argument
+         */
+        const std::int32_t size;
+
+        /**
+         * read from socket buffer size
+         */
+        static const Option<std::int32_t> READ_BUFFER_SIZE_TYPE;
+
+        /**
+         * When reading from socket, we define the timeout
+         */
+        static const Option<struct timeval> READ_TIMEOUT;
+
+        /**
+         * Minimum number of bytes to consider the buffer as readable
+         * Can be useful if want to use batch messages
+         */
+        static const Option<std::int32_t>
+            MINIMUM_BYTES_TO_CONSIDER_BUFFER_AS_READABLE;
+    };
+
+    template <typename VALUE_TYPE>
+    struct OptionValue
+    {
+      public:
+        OptionValue(const VALUE_TYPE value_type,
+                    const Option<VALUE_TYPE>& type);
+
+        /**
+         * Since the options are static instances, we can use lvalue here
+         */
+        const Option<VALUE_TYPE>& type;
+
+        const VALUE_TYPE value_type;
+    };
+
+    template <typename TYPE>
+    void option(const OptionValue<TYPE> option) const;
+
   protected:
     const struct sockaddr_in address;
 };

--- a/source/server.cpp
+++ b/source/server.cpp
@@ -18,6 +18,22 @@
 using namespace std;
 using namespace easykey;
 
+namespace easykey
+{
+template <>
+Socket::Option<int32_t> const Socket::Option<int32_t>::READ_BUFFER_SIZE_TYPE(
+    SO_RCVBUF);
+
+template <>
+Socket::Option<struct timeval> const Socket::Option<
+    struct timeval>::READ_TIMEOUT(SO_RCVTIMEO);
+
+template <>
+Socket::Option<int32_t> const Socket::Option<
+    int32_t>::MINIMUM_BYTES_TO_CONSIDER_BUFFER_AS_READABLE(SO_RCVLOWAT);
+
+};  // namespace easykey
+
 /**
  * Builds a server socket.
  * This is necessary, because the socket variable is const,
@@ -36,6 +52,34 @@ Socket::~Socket()
 {
     epoll.del(file_descriptor);
     close(file_descriptor);
+}
+
+template <typename TYPE>
+void Socket::option(const OptionValue<TYPE> option) const
+{
+    int32_t level = SOL_SOCKET;
+    int32_t opt_name = option.type.value;
+    TYPE t = option.value_type;
+    void *opt_value = &(t);
+    socklen_t opt_len = option.type.size;
+    if (::setsockopt(file_descriptor, level, opt_name, opt_value, opt_len) ==
+        -1)
+    {
+        perror("setsockopt");
+    }
+}
+
+template <typename OPTION_TYPE>
+Socket::Option<OPTION_TYPE>::Option(const int32_t value)
+    : value(value), size(sizeof(OPTION_TYPE))
+{
+}
+
+template <typename VALUE_TYPE>
+Socket::OptionValue<VALUE_TYPE>::OptionValue(const VALUE_TYPE value_type,
+                                             const Option<VALUE_TYPE> &type)
+    : type(type), value_type(value_type)
+{
 }
 
 ServerSocket::ServerSocket(const int32_t file_descriptor,


### PR DESCRIPTION
With c++ templates which are constructed at compile time, we can guarantee that only the specific fields that we want to let user define are allowed.