### PR TITLE
refactor: Free after use of clients object

### DIFF
--- a/clients/EasyKeyV1Client-Cli-Read.c
+++ b/clients/EasyKeyV1Client-Cli-Read.c
@@ -65,12 +65,15 @@ int main(int argc, char** argv)
 
     EasyKeyV1Response* response = read_response(&server);
     print_server_response(response);
+    
+    bool success = response->status_code == OK; 
+    free_easykey_request(request);
+    free_easykey_response(response);
 
-    if (response->status_code != OK)
+    if (!success)
     {
         return 1;
     }
-
     return 0;
 
 }

--- a/clients/EasyKeyV1Client-Cli-Write.c
+++ b/clients/EasyKeyV1Client-Cli-Write.c
@@ -116,8 +116,12 @@ int main(int argc, char** argv)
 
     EasyKeyV1Response* response = read_response(&server);
     print_server_response(response);
-    
-    if (response->status_code != OK)
+
+    bool success = response->status_code == OK; 
+    free_easykey_request(request);
+    free_easykey_response(response);
+
+    if (!success)
     {
         return 1;
     }

--- a/clients/easykeyv1-clients.c
+++ b/clients/easykeyv1-clients.c
@@ -165,3 +165,24 @@ char * duplicate_string(const char* string)
     memcpy(output, string, size);
     return output;
 }
+
+void free_easykey_request(EasyKeyV1Request* request) 
+{
+    for (int index = 0; index < request->messages_number; index++)
+    {
+        Array *array = request->messages[index];
+        free(array->array);
+        free(array);
+        request->messages[index] = NULL;
+    }
+    free(request->messages);
+    request->messages = NULL;
+    free(request);
+}
+
+void free_easykey_response(EasyKeyV1Response* response)
+{
+    free(response->value.array);
+    response->value.array = NULL;
+    free(response);
+}

--- a/clients/easykeyv1-clients.h
+++ b/clients/easykeyv1-clients.h
@@ -81,4 +81,8 @@ void print_server_response(const EasyKeyV1Response*);
 
 char * duplicate_string(const char *);
 
+void free_easykey_request(EasyKeyV1Request*);
+void free_easykey_response(EasyKeyV1Response*);
+
+
 #endif /* _EASYKEY_V1_CLIENT__ */


### PR DESCRIPTION
Even not necessary, cause the operation system deallocates everything after the process exits.
To make the use of valgrind, and to not have false negatives, its good to clean after use.